### PR TITLE
format version as only numbers and dots, since required in plugin.xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh './mvnw clean package'
+        sh './mvnw clean package -B -Dbuildnum=${BUILD_NUMBER}'
       }
     }
     stage('Archive JAR') {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.sonatype.iq.integration.fortify</groupId>
   <artifactId>parent</artifactId>
-  <version>19.2.1-SNAPSHOT</version>
+  <version>19.2.1.${buildnum}</version>
   <packaging>pom</packaging>
 
   <name>Sonatype Fortify SSC Integration</name>


### PR DESCRIPTION
having a version ending in -SNAPSHOT chokes SSC plugin loading...