### PR TITLE
configure minimum IQ threat level corresponding to SSC priority

### DIFF
--- a/sonatype-fortify-bundle/src/IntegrationService/iqapplication.properties
+++ b/sonatype-fortify-bundle/src/IntegrationService/iqapplication.properties
@@ -24,6 +24,7 @@ iq.report.type=vulnerabilities
 priority.critical=8
 priority.high=4
 priority.medium=2
+# any lower threat level is low priority
 
 # directory/file where log files are stored
 logfile.location=.work/Servicelog.log

--- a/sonatype-fortify-bundle/src/IntegrationService/iqapplication.properties
+++ b/sonatype-fortify-bundle/src/IntegrationService/iqapplication.properties
@@ -20,6 +20,11 @@ update.mapping.file=true
 # Define which report type to view (raw, vulnerabilities, policy = default)
 iq.report.type=vulnerabilities
 
+# Define custom minimum IQ threat level for SSC priority
+priority.critical=8
+priority.high=4
+priority.medium=2
+
 # directory/file where log files are stored
 logfile.location=.work/Servicelog.log
 logLevel=info

--- a/sonatype-fortify-integration/iqapplication.properties
+++ b/sonatype-fortify-integration/iqapplication.properties
@@ -4,16 +4,16 @@
 iqserver.url=http://localhost:8070/
 
 # Sonatype (IQ) server username
-iqserver.username=<USERNAME>
+iqserver.username=admin
 
 # Sonatype (IQ) server password
-iqserver.password=<PASSWORD>
+iqserver.password=admin123
 
 # Fortify (SSC) server URL
-sscserver.url=http://10.0.40.11:8180/ssc/
+sscserver.url=http://localhost:8088/ssc/
 
 # Fortify (SSC) server CIToken token https://www.microfocus.com/documentation/fortify-software-security-center/2010/SSC_Help_20.1.0/index.htm#SSC_UG/Gen_Auth_Tokens.htm
-sscserver.token=<encoded CIToken token>
+sscserver.token=OTQwODFmZGMtMjNmZS00NGNjLWI2ZjEtOGU5MDdhMGNiMmI2
 
 # Name and location of mapping JSON file.
 mapping.file=mapping.json
@@ -24,6 +24,11 @@ update.mapping.file=true
 
 # Define which report type to view (raw, vulnerabilities, policy = default)
 iq.report.type=policy
+
+# Define custom minimum IQ threat level for SSC priority
+#priority.critical=8
+#priority.high=4
+#priority.medium=2
 
 # Mandatory Fields read only on start, need to restart the service if changed.
 ################################################################################################

--- a/sonatype-fortify-integration/iqapplication.properties
+++ b/sonatype-fortify-integration/iqapplication.properties
@@ -29,6 +29,7 @@ iq.report.type=policy
 #priority.critical=8
 #priority.high=4
 #priority.medium=2
+# any lower threat level is low priority
 
 # Mandatory Fields read only on start, need to restart the service if changed.
 ################################################################################################

--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/ApplicationProperties.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/ApplicationProperties.java
@@ -98,6 +98,35 @@ public class ApplicationProperties implements Closeable
     this.sscServerToken = sscServerToken;
   }
 
+  private int priorityCritical;
+  private int priorityHigh;
+  private int priorityMedium;
+
+
+  public int getPriorityCritical() {
+    return priorityCritical;
+  }
+
+  public void setPriorityCritical(int priorityCritical) {
+    this.priorityCritical = priorityCritical;
+  }
+
+  public int getPriorityHigh() {
+    return priorityHigh;
+  }
+
+  public void setPriorityHigh(int priorityHigh) {
+    this.priorityHigh = priorityHigh;
+  }
+
+  public int getPriorityMedium() {
+    return priorityMedium;
+  }
+
+  public void setPriorityMedium(int priorityMedium) {
+    this.priorityMedium = priorityMedium;
+  }
+
   private File mapFile;
 
   public File getMapFile() {

--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/util/ApplicationPropertiesLoader.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/util/ApplicationPropertiesLoader.java
@@ -67,6 +67,10 @@ public class ApplicationPropertiesLoader
     }
     appProp.setIqReportType(iqReportType);
 
+    appProp.setPriorityCritical(Integer.parseInt(properties.getProperty("priority.critical", "8")));
+    appProp.setPriorityHigh(Integer.parseInt(properties.getProperty("priority.high", "4")));
+    appProp.setPriorityMedium(Integer.parseInt(properties.getProperty("priority.medium", "2")));
+
     String loadfileLocation = properties.getProperty("loadfile.location");
     if (verifyIsNotNull(loadfileLocation)) {
       appProp.setLoadLocation(new File(loadfileLocation));


### PR DESCRIPTION
by default, minimum threat level is configured as defined in https://help.sonatype.com/iqserver/managing/policy-management/understanding-the-parts-of-a-policy
but sometimes, people will want to map to SSC with different thresholds

this PR permits to configure values in `iqapplication.properties`:
```
# Define custom minimum IQ threat level for SSC priority
priority.critical=8
priority.high=4
priority.medium=2
```