### PR TITLE
add scan initiator data to report sent to SSC

### DIFF
--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/iq/IQClient.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/iq/IQClient.java
@@ -167,6 +167,7 @@ public class IQClient implements Closeable
    * @param internalAppId the internal app id
    * @param stage the requested stage
    * @return a Sonatype scan initialised with key IQ report data
+   * @since IQ release 94
    */
   public Report getScanReportFromHistory(String internalAppId, String stage) {
     String result = callIqServerGET(API_REPORTS_APPLICATIONS_HISTORY, internalAppId);

--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/iq/policyViolation/PolicyViolationResponse.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/iq/policyViolation/PolicyViolationResponse.java
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
     "reportTime",
     "reportTitle",
+    "commitHash",
+    "initiator",
     "application",
     "counts",
     "components"
@@ -25,6 +27,10 @@ public class PolicyViolationResponse {
     private long reportTime;
     @JsonProperty("reportTitle")
     private String reportTitle;
+    @JsonProperty("commitHash")
+    private String commitHash; // since IQ release 92
+    @JsonProperty("initiator")
+    private String initiator; // since IQ release 98
     @JsonProperty("application")
     private Application application;
     @JsonProperty("counts")
@@ -52,6 +58,26 @@ public class PolicyViolationResponse {
     @JsonProperty("reportTitle")
     public void setReportTitle(String reportTitle) {
         this.reportTitle = reportTitle;
+    }
+
+    @JsonProperty("commitHash")
+    public String getCommitHash() {
+        return commitHash;
+    }
+
+    @JsonProperty("commitHash")
+    public void setCommitHash(String commitHash) {
+        this.commitHash = commitHash;
+    }
+
+    @JsonProperty("initiator")
+    public String getInitiator() {
+        return initiator;
+    }
+
+    @JsonProperty("initiator")
+    public void setInitiator(String initiator) {
+        this.initiator = initiator;
     }
 
     @JsonProperty("application")

--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/service/IQFortifyIntegrationService.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/service/IQFortifyIntegrationService.java
@@ -168,7 +168,7 @@ public class IQFortifyIntegrationService
       PolicyViolationResponse policyViolationResponse = iqClient.getPolicyViolationsByReport(project,
           reportData.getReportId());
 
-      // fill build server field with "scan by <initiator>"/"reevaluation by <initiator>"/"continuous monitoring"
+      // fill build server field with "<type>,<initiator>", with type=isNew/isReevaluation/isForMonitoring
       // it will be displayed in SSC "ARTIFACTS" view as "Hostname"
       String buildServer = "unknown";
       // require data from scan history (available since IQ release 94)
@@ -176,14 +176,14 @@ public class IQFortifyIntegrationService
         Report report = iqClient.getScanReportFromHistory(internalAppId, stage);
         if (report != null) {
           if (report.getIsForMonitoring()) {
-            buildServer = "continuous monitoring";
+            buildServer = "isForMonitoring";
           }
           else {
-            buildServer = report.getIsReevaluation() ? "reevaluation" : "scan";
+            buildServer = report.getIsReevaluation() ? "isReevaluation" : "isNew";
           }
           String initiator = policyViolationResponse.getInitiator();
           if (StringUtils.isNotEmpty(initiator)) {
-            buildServer += " by " + initiator;
+            buildServer += "," + initiator;
           }
         }
       } catch (Exception e) {

--- a/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/service/IQFortifyIntegrationService.java
+++ b/sonatype-fortify-integration/src/main/java/com/sonatype/ssc/intsvc/service/IQFortifyIntegrationService.java
@@ -163,22 +163,35 @@ public class IQFortifyIntegrationService
       return null;
     }
 
-    // get data from scan history
-    try {
-      Report report = iqClient.getScanReportFromHistory(internalAppId, stage);
-      if (report != null) {
-        // store "new scan" vs "reevaluation" vs "continuous monitoring" in "build server" field (displayed in SSC artifact view)
-        scan.setBuildServer(report.getIsForMonitoring() ? "isForMonitoring" : (report.getIsReevaluation() ? "isReevaluation" : "isNew"));
-      }
-    } catch (Exception e) {
-      // optional data, don't fail: perhaps just an older IQ release
-      logger.warn("getScanReportFromHistory(" + project + ", " + stage + "):" + e.getMessage(), e);
-    }
-
     try {
       // extract policy violations from IQ report
       PolicyViolationResponse policyViolationResponse = iqClient.getPolicyViolationsByReport(project,
           reportData.getReportId());
+
+      // fill build server field with "scan by <initiator>"/"reevaluation by <initiator>"/"continuous monitoring"
+      // it will be displayed in SSC "ARTIFACTS" view as "Hostname"
+      String buildServer = "unknown";
+      // require data from scan history (available since IQ release 94)
+      try {
+        Report report = iqClient.getScanReportFromHistory(internalAppId, stage);
+        if (report != null) {
+          if (report.getIsForMonitoring()) {
+            buildServer = "continuous monitoring";
+          }
+          else {
+            buildServer = report.getIsReevaluation() ? "reevaluation" : "scan";
+          }
+          String initiator = policyViolationResponse.getInitiator();
+          if (StringUtils.isNotEmpty(initiator)) {
+            buildServer += " by " + initiator;
+          }
+        }
+      } catch (Exception e) {
+        // optional data, don't fail: probably just an older IQ release
+        buildServer = "require IQ 94";
+        logger.warn("getScanReportFromHistory(" + project + ", " + stage + "): please upgrade Nexus IQ to release 94 minimum", e);
+      }
+      scan.setBuildServer(buildServer);
 
       scan.setNumberOfFiles(policyViolationResponse.getCounts().getTotalComponentCount());
 

--- a/sonatype-fortify-integration/src/test/java/com/sonatype/ssc/intsvc/TestSonatypeController.java
+++ b/sonatype-fortify-integration/src/test/java/com/sonatype/ssc/intsvc/TestSonatypeController.java
@@ -132,6 +132,13 @@ public class TestSonatypeController
       // obviously not reproducible field: TODO check format
       json.remove("scanDate");
       ref.remove("scanDate");
+
+      // check buildServer format (non-reproducible value)
+      ref.remove("buildServer");
+      String buildServer = json.remove("buildServer").toString();
+      assertTrue(buildServer.startsWith("scan by ") || buildServer.startsWith("reevaluation by ")
+          || buildServer.equals("continuous monitoring"));
+
       // check other fields
       @SuppressWarnings("unchecked")
       Set<Map.Entry<String, Object>> values = ref.entrySet();
@@ -156,7 +163,7 @@ public class TestSonatypeController
         current = getFindingKey(finding);
         JSONObject refFinding = findingsMap.remove(current);
         if (refFinding == null) {
-          assertTrue("Finding with key = " + current, false);
+          assertTrue("Finding with key = " + current + " missing from reference", false);
         }
         compareFinding(refFinding, finding);
       }

--- a/sonatype-fortify-integration/src/test/java/com/sonatype/ssc/intsvc/TestSonatypeController.java
+++ b/sonatype-fortify-integration/src/test/java/com/sonatype/ssc/intsvc/TestSonatypeController.java
@@ -136,8 +136,8 @@ public class TestSonatypeController
       // check buildServer format (non-reproducible value)
       ref.remove("buildServer");
       String buildServer = json.remove("buildServer").toString();
-      assertTrue(buildServer.startsWith("scan by ") || buildServer.startsWith("reevaluation by ")
-          || buildServer.equals("continuous monitoring"));
+      assertTrue(buildServer.startsWith("isNew,") || buildServer.startsWith("isReevaluation,")
+          || buildServer.startsWith("isForMonitoring,"));
 
       // check other fields
       @SuppressWarnings("unchecked")

--- a/sonatype-fortify-integration/src/test/resources/Sonatype-Fortify-integration-sample-application-scan.json
+++ b/sonatype-fortify-integration/src/test/resources/Sonatype-Fortify-integration-sample-application-scan.json
@@ -1,7 +1,7 @@
 {
   "engineVersion": "1.0",
   "numberOfFiles": 50,
-  "buildServer": "isNew",
+  "buildServer": "isNew,user1",
   "findings": [
     {
       "fileName": "pkg:golang/golang.org/x/text@v0.3.0",


### PR DESCRIPTION
message will be displayed in SSC "ARTIFACTS" view as "Hostname" with "scan by \<initiator>", "reevaluation by \<initiator>" or "continuous monitoring" instead of previous "isNew", "isReevaluation" or "isForMonitoring"

this requires IQ release 98, or the message won't contain "by \<initiator>" part